### PR TITLE
exclude license from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 build/
 .env
+**/kendo-ui-license**


### PR DESCRIPTION
Excluding the license from gitignore so that someone does not commit a license file